### PR TITLE
Add Rename Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,7 @@ Allows you to use `__name__` syntax in your prompt to get a random line from a f
 
 Allows you to sort generated images into folders based on a specified wildcard. 
 
-When enabled, `character` will look for the instances of `__character__` in a prompt and save images into the directory `/sorted/characters/{charactername}.{extension}`
+When sort is enabled, `character` will look for the instances of `__character__` in a prompt and save images into the directory `/sorted/characters/{default_file_name #}.{extension}`
 Providing an invalid wildcard will save to the default save path.
+
+If rename is enabled, images will not duplicate into a `sorted` folder. Instead they will be renamed `{default_file_name #} character {character name}.{extension}`

--- a/scripts/wildcards.py
+++ b/scripts/wildcards.py
@@ -2,6 +2,7 @@ import os
 import random
 import sys
 import shutil
+import re
 from modules import scripts, script_callbacks, shared
 from modules.script_callbacks import ImageSaveParams
 
@@ -87,15 +88,43 @@ def create_if_not_exist(dirs: list):
             os.makedirs(dir)
 
 
+def on_before_image_saved(params: ImageSaveParams):
+    if (shared.opts.enable_wildcard_sort
+            and wildcard_sort_name
+            and shared.opts.wildcard_key
+            and shared.opts.enable_wildcard_rename):
+        orig_param = params
+        try:
+            file_name_ext = os.path.splitext(
+                os.path.basename(params.filename))
+            save_dir = os.path.dirname(params.filename)
+            new_name = f"{file_name_ext[0].strip()} {shared.opts.wildcard_key.strip()} {wildcard_sort_name.strip()}{file_name_ext[1]}"
+            params.filename = os.path.join(save_dir, new_name)
+        except Exception as e:
+            print("Failed to rename file, restoring default")
+            print(e)
+            params = orig_param
+    return params
+
+
 def on_image_saved(params: ImageSaveParams):
     # callback sets image path to the new directory if sort is enabled
-    if shared.opts.enable_wildcard_sort and wildcard_sort_name and shared.opts.wildcard_key:
-        base_name = os.path.basename(params.filename)
-        new_dir = params.filename.replace(
-            base_name, f"/sorted/{shared.opts.wildcard_key}s/{wildcard_sort_name}")
-        create_if_not_exist([new_dir])
-        shutil.copy(params.filename, os.path.realpath(
-            f"{new_dir}/{base_name}"))
+    if (shared.opts.enable_wildcard_sort
+            and wildcard_sort_name
+            and shared.opts.wildcard_key
+            and not shared.opts.enable_wildcard_rename):
+        orig_param = params
+        try:
+            base_name = os.path.basename(params.filename)
+            new_dir = params.filename.replace(
+                base_name, f"/sorted/{shared.opts.wildcard_key}s/{wildcard_sort_name}")
+            create_if_not_exist([new_dir])
+            shutil.copy(params.filename, os.path.realpath(
+                f"{new_dir}/{base_name}"))
+        except Exception as e:
+            print("Failed to sort file, restoring default")
+            print(e)
+            params = orig_param
     return params
 
 
@@ -103,10 +132,13 @@ def on_ui_settings():
     shared.opts.add_option("wildcards_same_seed", shared.OptionInfo(
         False, "Use same seed for all images", section=("wildcards", "Wildcards")))
     shared.opts.add_option("enable_wildcard_sort", shared.OptionInfo(
-        False, "Enable wildcard Sort", section=("wildcards", "Wildcards")))
+        False, "Enable Wildcard Sort (creates duplicate images in a sort folder if rename is not enabled.)", section=("wildcards", "Wildcards")))
+    shared.opts.add_option("enable_wildcard_rename", shared.OptionInfo(
+        False, "Enable Renaming (renames with sort key)", section=("wildcards", "Wildcards")))
     shared.opts.add_option("wildcard_key", shared.OptionInfo(
         "character", "Wildcard to sort image by", section=("wildcards", "Wildcards")))
 
 
 script_callbacks.on_ui_settings(on_ui_settings)
 script_callbacks.on_image_saved(on_image_saved)
+script_callbacks.on_before_image_saved(on_before_image_saved)


### PR DESCRIPTION
Problem:
Sorted images must remain in the default output folder for the image preview functionality to remain working.
Images sorted are not moved but rather duplicated into a sorted folder creating double file size effectively.
Solution:
A new setting that allows for appending wildcard settings to the filename for easy searching rather than sorting. This functionality can be enabled or disabled via a setting.